### PR TITLE
Just use the default log level for reconfigure

### DIFF
--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -254,7 +254,7 @@ module Omnibus
     end
 
     def reconfigure(*args)
-      status = run_command("#{base_path}/bin/chef-solo -c #{base_path}/embedded/cookbooks/solo.rb -j #{base_path}/embedded/cookbooks/dna.json -l info")
+      status = run_command("#{base_path}/bin/chef-solo -c #{base_path}/embedded/cookbooks/solo.rb -j #{base_path}/embedded/cookbooks/dna.json")
       if status.success?
         log "#{display_name} Reconfigured!"
         exit! 0


### PR DESCRIPTION
No need to force the log level to info. In Chef < 11, info is the default, and in Chef 11, a new setting "auto" is the default. Allowing the log level to be "auto" in Chef 11 gets rid of the info messages that clutter the output and are generally duplicates of the messages that the output formatters display nicely.
