### PR TITLE
Allow omnibus-ctl to be invoked without having the service management commands.

### DIFF
--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -60,16 +60,16 @@ module Omnibus
           :arity => 1,
           :desc => "Kill all processes and uninstall the process supervisor (data will be preserved)."
         },
-        "service-list" => {
-          :arity => 1,
-          :desc => "List all the services (enabled services appear with a *.)"
-        },
         "help" => {
           :arity => 1,
           :desc => "Print this help message."
         }
       }
       service_command_map = {
+        "service-list" => {
+          :arity => 1,
+          :desc => "List all the services (enabled services appear with a *.)"
+        },
         "status" => {
           :desc => "Show the status of all the services.",
           :arity => 2

--- a/spec/omnibus-ctl_spec.rb
+++ b/spec/omnibus-ctl_spec.rb
@@ -23,10 +23,10 @@ describe Omnibus::Ctl do
           reconfigure
           cleanse
           uninstall
-          service-list
           help
   }
   service_commands = %w{
+          service-list
           status
           tail
           start


### PR DESCRIPTION
Addons (e.g. pushy/reporting/manage) don't manage their own services but use the private-chef-ctl runit.

This patch allows for a second initialization option 'service_commands' (true by default to mimic current behaviour) where the ctl command does not have any runit related commands.  Includes updated tests

Note:  This doesn't include a new wrapper script ala. omnibus-ctl - I'm dropping off a script setting the options directly in the relevant omnibus software config (e.g. omnibus-reporting-ctl)

cc @christophermaier, @schisamo 
