### PR TITLE
Use null formatter when running chef-solo in show_config.

### DIFF
--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -482,7 +482,7 @@ EOM
     end
 
     def show_config(*args)
-      status = run_chef("#{base_path}/embedded/cookbooks/show-config.json", "-l fatal")
+      status = run_chef("#{base_path}/embedded/cookbooks/show-config.json", "-l fatal -F null")
       exit! status.success? ? 0 : 1
     end
 


### PR DESCRIPTION
Using the null formatter ensures that the command only outputs the
configuration.  This allows other programs to use its output more
easily.