### PR TITLE
[OC-11574] Do not interact with keepalived by default.

### DIFF
--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -250,6 +250,7 @@ module Omnibus
       exit_status = 0
       get_all_services.each do |service_name|
         next if !service.nil? && service_name != service
+        next if service_name == "keepalived" && service != "keepalived" && sv_cmd != "status"
         if service_enabled?(service_name)
           status = run_command("#{base_path}/init/#{service_name} #{sv_cmd}")
           exit_status = status.exitstatus if exit_status == 0 && !status.success?


### PR DESCRIPTION
In HA topologies, keepalived is responsible for managing failover
between the machines.  If the keepalived service is stopped, a
failover occurs.  Typically, when I user runs `private-chef-ctl
restart`, they do not expect a failover to occur.

This patch ensures that we only modify the state of the keepalived
service when explicitly told to.
