### PR TITLE
blacklist removed services from *-ctl commands

### DIFF
--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -297,8 +297,16 @@ module Omnibus
     # removed services are configured via the attributes file in
     # the main omnibus cookbook
     def removed_services
-      key = package_name.gsub(/-/, '_')
-      running_config[key]["removed_services"] || []
+      # in the case that there is no running_config (the config file does
+      # not exist), we know that this will be a new server, and we don't
+      # have to worry about pre-upgrade services hanging around. We can safely
+      # return an empty array when running_config is nil
+      if (cfg = running_config)
+        key = package_name.gsub(/-/, '_')
+        cfg[key]["removed_services"] || []
+      else
+        []
+      end
     end
 
     # translate the name from the config to the package name.
@@ -314,6 +322,7 @@ module Omnibus
       end
     end
 
+    # returns nil when chef-server-running.json does not exist
     def running_config
       @running_config ||= begin
         if File.exists?("#{etc_path}/chef-server-running.json")

--- a/spec/omnibus-ctl_spec.rb
+++ b/spec/omnibus-ctl_spec.rb
@@ -477,6 +477,59 @@ describe Omnibus::Ctl do
         @ctl.removed_services.should eq([])
       end
     end
+
+    context "when #running_config returns nil" do
+      before(:each) do
+        @ctl.stub(:running_config).and_return(nil)
+      end
+
+      it "should return an empty array" do
+        @ctl.removed_services.should eq([])
+      end
+    end
+  end
+
+  describe "running_config" do
+    let(:file_path) { "/etc/chef-server/chef-server-running.json" }
+    let(:file_contents) do
+      <<EOF
+{"chef_server": {"attr1":true,"removed_services":["sv1","sv2"]}}
+EOF
+end
+
+    it "checks if the file exists" do
+      File.should_receive(:exists?).with(file_path).and_return(false)
+      @ctl.running_config
+    end
+
+    context "when the file exists" do
+      before(:each) do
+        File.stub(:exists?).and_return(true)
+      end
+
+      it "should return the parsed contents of the file" do
+        File
+          .should_receive(:read)
+          .with(file_path)
+          .and_return(file_contents)
+        expected = { "chef_server" =>
+          { "attr1" => true,
+            "removed_services" => ["sv1", "sv2"]
+          }
+        }
+        @ctl.running_config.should eq(expected)
+      end
+    end
+
+    context "when the file doesn't exist" do
+      before(:each) do
+        File.stub(:exists?).and_return(false)
+      end
+
+      it "should return nil" do
+        @ctl.running_config.should eq(nil)
+      end
+    end
   end
 
   describe "package_name" do


### PR DESCRIPTION
When running omnibus-ctl [status|start|restart|etc] for services
that have been removed and are configured as removed (requires
config to be written by the *-omnibus projects), we should not
attempt to start the services or run any service commands against
them unless specifically attempting to do so. Services that are
removed can still be accessed by running:

```
*-ctl SV_COMMAND REMOVED_SERVICE
```

The previous behavior manifested itself as a race condition in
Enterprise Chef where a service that was previously installed as
part of an older version came up after a `*-ctl start` and stole
the port from the service that was supposed to be running. This
fixes that issue.

/cc @opscode/server-team @stevendanna @jamesc @irvingpop @ryancragun 
