### PR TITLE
ignore config logs

### DIFF
--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -42,7 +42,7 @@ module Omnibus
       @log_path = "/var/log/#{name}"
       @data_path = "/var/opt/#{name}"
       @etc_path = "/etc/#{name}"
-      @log_exclude = '(lock|@|gzip|tgz|gz)'
+      @log_exclude = '(config|lock|@|gzip|tgz|gz)'
       @log_path_exclude = ['*/sasl/*']
       @fh_output = STDOUT
       @kill_users = []


### PR DESCRIPTION
[enterprise-chef-common](https://github.com/opscode-cookbooks/enterprise-chef-common/blob/1393728a5a061564a478ae6683a2382ac33de041/definitions/component_runit_service.rb#L17-L27) writes out "config" files in the log directories that show up in ctl tail commands. This ignores them in here.