### PR TITLE
Ignore default gzip extension gz.

### DIFF
--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -42,7 +42,7 @@ module Omnibus
       @log_path = "/var/log/#{name}"
       @data_path = "/var/opt/#{name}"
       @etc_path = "/etc/#{name}"
-      @log_exclude = '(lock|@|gzip|tgz)'
+      @log_exclude = '(lock|@|gzip|gz|tgz)'
       @log_path_exclude = ['*/sasl/*']
       @fh_output = STDOUT
       @kill_users = []


### PR DESCRIPTION
[By default](http://linux.die.net/man/1/gzip), gzip uses .gz as an extension. It would be nice to filter out these archives from `ctl tail` output.