### PR TITLE
Exclude gz from *-ctl tail

### DIFF
--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -42,7 +42,7 @@ module Omnibus
       @log_path = "/var/log/#{name}"
       @data_path = "/var/opt/#{name}"
       @etc_path = "/etc/#{name}"
-      @log_exclude = '(lock|@|gzip|tgz)'
+      @log_exclude = '(lock|@|gzip|tgz|gz)'
       @log_path_exclude = ['*/sasl/*']
       @fh_output = STDOUT
       @kill_users = []


### PR DESCRIPTION
Exclude binary gz data from `*-ctl tail` commands.  Fixes https://github.com/opscode/omnibus-ctl/issues/17
