### PR TITLE
Use chef-client -z instead of chef-solo and reference by the full path.

### DIFF
--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -386,7 +386,7 @@ module Omnibus
     end
 
     def show_config(*args)
-      status = run_command("chef-solo -c #{base_path}/embedded/cookbooks/solo.rb -j #{base_path}/embedded/cookbooks/show-config.json -l fatal")
+      status = run_command("#{base_path}/embedded/bin/chef-client -z -c #{base_path}/embedded/cookbooks/solo.rb -j #{base_path}/embedded/cookbooks/show-config.json -l fatal")
       if status.success?
         exit! 0
       else
@@ -395,7 +395,7 @@ module Omnibus
     end
 
     def reconfigure(exit_on_success=true)
-      status = run_command("chef-solo -c #{base_path}/embedded/cookbooks/solo.rb -j #{base_path}/embedded/cookbooks/dna.json")
+      status = run_command("#{base_path}/embedded/bin/chef-client -z -c #{base_path}/embedded/cookbooks/solo.rb -j #{base_path}/embedded/cookbooks/dna.json")
       if status.success?
         log "#{display_name} Reconfigured!"
         exit! 0 if exit_on_success


### PR DESCRIPTION
Uses `chef-client -z` instead of `chef-solo` which works around `chef-solo --no-fork` bug. Also `chef-solo` is going away in favor of `chef-client -z` soon, so this is work we will have to do anyway.

Also, prevent accidentally slurping in whatever is in the path by explicitly calling the full `/opt/opscode/embedded/bin` command since its just a system call. However, we should only do this if `chef-server-ctl` is the only project that uses the `show-config` and `reconfigure` commands. If that is not true, then just change to be `chef-client -z`.