### PR TITLE
Remove old node state before running reconfigure or show-config.

### DIFF
--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -385,7 +385,17 @@ module Omnibus
       end
     end
 
+    def remove_old_node_state
+      node_cache_path = "#{base_path}/embedded/nodes/"
+      status = run_command("rm -rf #{node_cache_path}")
+      if ! status.success?
+        log "Could not remove cached node state!"
+        exit! 1
+      end
+    end
+
     def show_config(*args)
+      remove_old_node_state
       status = run_command("#{base_path}/embedded/bin/chef-client -z -c #{base_path}/embedded/cookbooks/solo.rb -j #{base_path}/embedded/cookbooks/show-config.json -l fatal")
       if status.success?
         exit! 0
@@ -395,6 +405,7 @@ module Omnibus
     end
 
     def reconfigure(exit_on_success=true)
+      remove_old_node_state
       status = run_command("#{base_path}/embedded/bin/chef-client -z -c #{base_path}/embedded/cookbooks/solo.rb -j #{base_path}/embedded/cookbooks/dna.json")
       if status.success?
         log "#{display_name} Reconfigured!"


### PR DESCRIPTION
Currently, the reconfigure cookbooks for most projects using
omnibus-ctl include complex option processing where the final
configuration is merged into the node data.  Chef-client -z loads the
node state from the last run, which leads to situations in which a
user can remove configuration from the main configuration file but the
configuration isn't actually reverted to the default when reconfigure
is run.

In the long run we want to move away from overloading node attribtues
in this way. However, to avoid massive changes to the configuration
of a number of projects, we simply nuke the old node data.

Fixes chef/opscode-omnibus#730
Fixes chef/omnibus-ctl#24