### PR TITLE
Add a run_chef method to run chef-client -z

### DIFF
--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -398,9 +398,15 @@ module Omnibus
       end
     end
 
-    def show_config(*args)
+    def run_chef(attr_location, args='')
       remove_old_node_state
-      status = run_command("#{base_path}/embedded/bin/chef-client -z -c #{base_path}/embedded/cookbooks/solo.rb -j #{base_path}/embedded/cookbooks/show-config.json -l fatal")
+      cmd = "#{base_path}/embedded/bin/chef-client -z -c #{base_path}/embedded/cookbooks/solo.rb -j #{attr_location}"
+      cmd += " #{args}" unless args.empty?
+      run_command(cmd)
+    end
+
+    def show_config(*args)
+      status = run_chef("#{base_path}/embedded/cookbooks/show-config.json", "-l fatal")
       if status.success?
         exit! 0
       else
@@ -409,8 +415,7 @@ module Omnibus
     end
 
     def reconfigure(exit_on_success=true)
-      remove_old_node_state
-      status = run_command("#{base_path}/embedded/bin/chef-client -z -c #{base_path}/embedded/cookbooks/solo.rb -j #{base_path}/embedded/cookbooks/dna.json")
+      status = run_chef("#{base_path}/embedded/cookbooks/dna.json")
       if status.success?
         log "#{display_name} Reconfigured!"
         exit! 0 if exit_on_success


### PR DESCRIPTION
The remove_old_node_state function needs to be called before any
invocation of chef-client -z to account for previous run state that
might be on disk.  Providing a run_chef method will make it easy for
project-specific ctl commands to do this correctly.