### PR TITLE
Update RSpec to 3.2; remove warnings

### DIFF
--- a/omnibus-ctl.gemspec
+++ b/omnibus-ctl.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = %q{Provides command line control for omnibus pakcages, rarely used as a gem}
 
   # specify any dependencies here; for example:
-  s.add_development_dependency "rspec"
+  s.add_development_dependency "rspec", "~> 3.2"
   s.add_development_dependency "rspec_junit_formatter"
 
   s.bindir       = "bin"

--- a/spec/omnibus-ctl_spec.rb
+++ b/spec/omnibus-ctl_spec.rb
@@ -49,19 +49,19 @@ describe Omnibus::Ctl do
 
   describe "initialize" do
     it "returns an Omnibus::Ctl instance" do
-      Omnibus::Ctl.new("chef-server").should be_a_kind_of(Omnibus::Ctl)
+      expect(Omnibus::Ctl.new("chef-server")).to be_a_kind_of(Omnibus::Ctl)
     end
 
     it "sets the name accessor to the first argument" do
-      Omnibus::Ctl.new("chef-server").name.should == "chef-server"
+      expect(Omnibus::Ctl.new("chef-server").name).to eq("chef-server")
     end
 
     it "sets the fh_output to STDOUT" do
-      Omnibus::Ctl.new("chef-server").fh_output.should === STDOUT
+      expect(Omnibus::Ctl.new("chef-server").fh_output).to be === STDOUT
     end
 
     it "by default controls services" do
-      Omnibus::Ctl.new("chef-server").service_commands?.should == true
+      expect(Omnibus::Ctl.new("chef-server").service_commands?).to eq(true)
     end
   end
 
@@ -69,7 +69,7 @@ describe Omnibus::Ctl do
     it "should return all the commands in a top-level hash" do
 
       all_commands.each do |cmd|
-        @ctl.get_all_commands_hash.has_key?(cmd).should == true
+        expect(@ctl.get_all_commands_hash.has_key?(cmd)).to eq(true)
       end
     end
 
@@ -82,13 +82,13 @@ describe Omnibus::Ctl do
 
       it "should contain the service commands in the top-level of the result" do
         standard_commands.each do |cmd|
-          @ctl.get_all_commands_hash.has_key?(cmd).should == true
+          expect(@ctl.get_all_commands_hash.has_key?(cmd)).to eq(true)
         end
       end
 
       it "should not contain the service commands in the top-level of the result" do
         service_commands.each do |cmd|
-          @ctl.get_all_commands_hash.has_key?(cmd).should == false
+          expect(@ctl.get_all_commands_hash.has_key?(cmd)).to eq(false)
         end
       end
     end
@@ -97,19 +97,19 @@ describe Omnibus::Ctl do
   describe "category_command_map" do
     standard_commands.each do |cmd|
       it "has #{cmd} by default under general category" do
-        @ctl.category_command_map["general"].has_key?(cmd).should == true
+        expect(@ctl.category_command_map["general"].has_key?(cmd)).to eq(true)
       end
     end
 
     service_commands.each do |cmd|
       it "has #{cmd} by default under service-management category" do
-        @ctl.category_command_map["service-management"].has_key?(cmd).should == true
+        expect(@ctl.category_command_map["service-management"].has_key?(cmd)).to eq(true)
       end
     end
 
     it "has no commands that are not tested by default" do
       @ctl.command_map.each_key do |cmd|
-        all_commands.include?(cmd).should == true
+        expect(all_commands.include?(cmd)).to eq(true)
       end
     end
 
@@ -121,23 +121,23 @@ describe Omnibus::Ctl do
 
       standard_commands.each do |cmd|
         it "has #{cmd} by default in general category" do
-          @ctl.category_command_map["general"].has_key?(cmd).should == true
+          expect(@ctl.category_command_map["general"].has_key?(cmd)).to eq(true)
         end
       end
 
       service_commands.each do |cmd|
         it "does not have service command #{cmd} by default" do
-          @ctl.command_map.has_key?(cmd).should == false
+          expect(@ctl.command_map.has_key?(cmd)).to eq(false)
         end
       end
 
       it "should not have service-management category by default" do
-          @ctl.command_map.has_key?("service-management").should == false
+          expect(@ctl.command_map.has_key?("service-management")).to eq(false)
       end
 
       it "has no commands that are not tested by default" do
         @ctl.category_command_map["general"].each_key do |cmd|
-          standard_commands.include?(cmd).should == true
+          expect(standard_commands.include?(cmd)).to eq(true)
         end
       end
     end
@@ -147,20 +147,20 @@ describe Omnibus::Ctl do
     it "puts to the fh_output" do
       @ctl.log("you really should see this!")
       @ctl.fh_output.rewind
-      @ctl.fh_output.gets(nil).should == "you really should see this!\n"
+      expect(@ctl.fh_output.gets(nil)).to eq("you really should see this!\n")
     end
   end
 
   describe "help" do
     all_commands.each do |cmd|
       it "prints the #{cmd} command and description" do
-        @ctl.stub(:exit!).and_return(true)
+        allow(@ctl).to receive(:exit!).and_return(true)
         @ctl.help
         @ctl.fh_output.rewind
         output = @ctl.fh_output.gets(nil)
         # depending on whether or not the command has a category,
         # it will have extra spaces
-        output.should =~ /  #{Regexp.escape(cmd)}\n    #{Regexp.escape(@ctl.get_all_commands_hash[cmd][:desc])}|#{Regexp.escape(cmd)}\n  #{Regexp.escape(@ctl.get_all_commands_hash[cmd][:desc])}/ 
+        expect(output).to match(/  #{Regexp.escape(cmd)}\n    #{Regexp.escape(@ctl.get_all_commands_hash[cmd][:desc])}|#{Regexp.escape(cmd)}\n  #{Regexp.escape(@ctl.get_all_commands_hash[cmd][:desc])}/) 
       end
     end
 
@@ -172,40 +172,40 @@ describe Omnibus::Ctl do
 
       standard_commands.each do |cmd|
         it "prints the #{cmd} command and description" do
-          @ctl.stub(:exit!).and_return(true)
+          allow(@ctl).to receive(:exit!).and_return(true)
           @ctl.help
           @ctl.fh_output.rewind
           output = @ctl.fh_output.gets(nil)
-          output.should =~ /  #{Regexp.escape(cmd)}\n    #{Regexp.escape(@ctl.get_all_commands_hash[cmd][:desc])}|#{Regexp.escape(cmd)}\n  #{Regexp.escape(@ctl.get_all_commands_hash[cmd][:desc])}/ 
+          expect(output).to match(/  #{Regexp.escape(cmd)}\n    #{Regexp.escape(@ctl.get_all_commands_hash[cmd][:desc])}|#{Regexp.escape(cmd)}\n  #{Regexp.escape(@ctl.get_all_commands_hash[cmd][:desc])}/) 
         end
       end
 
       service_commands.each do |cmd|
         it "does not print the #{cmd} command and description" do
-          @ctl.stub(:exit!).and_return(true)
+          allow(@ctl).to receive(:exit!).and_return(true)
           @ctl.help
           @ctl.fh_output.rewind
           output = @ctl.fh_output.gets(nil)
-          output.should_not =~ /#{Regexp.escape(cmd)}\n/
+          expect(output).not_to match(/#{Regexp.escape(cmd)}\n/)
         end
       end
     end
 
     it "exits 1" do
-      lambda { @ctl.help }.should raise_error(SystemExit)
+      expect { @ctl.help }.to raise_error(SystemExit)
     end
   end
 
   describe "exit!" do
     it "raises systemexit with the code specified" do
-      lambda { @ctl.exit! 15 }.should raise_error(SystemExit)
+      expect { @ctl.exit! 15 }.to raise_error(SystemExit)
       exit_code = nil
       begin
         @ctl.exit! 15
       rescue SystemExit => e
         exit_code = e.status
       end
-      exit_code.should == 15
+      expect(exit_code).to eq(15)
     end
   end
 
@@ -217,7 +217,7 @@ describe Omnibus::Ctl do
       rescue SystemExit => e
         exit_code = e.status
       end
-      exit_code.should == 1
+      expect(exit_code).to eq(1)
     end
 
     it "exits 2 if the command is found, but not with the arity you provided on the cli" do
@@ -227,12 +227,12 @@ describe Omnibus::Ctl do
       rescue SystemExit => e
         exit_code = e.status
       end
-      exit_code.should == 2
+      expect(exit_code).to eq(2)
     end
 
     it "runs the method describe by the command" do
-      @ctl.stub(:exit!).and_return(true)
-      @ctl.should_receive(:help).with("help")
+      allow(@ctl).to receive(:exit!).and_return(true)
+      expect(@ctl).to receive(:help).with("help")
       @ctl.run(["help"])
     end
   end
@@ -244,39 +244,39 @@ describe Omnibus::Ctl do
 
     it "loads the files in a path, and instance_evals them" do
       @ctl.extended
-      @ctl.run(["extended"]).should == true
-      @ctl.run(["arity"]).should == true
+      expect(@ctl.run(["extended"])).to eq(true)
+      expect(@ctl.run(["arity"])).to eq(true)
     end
 
     it "should let you add to the help output" do
-      @ctl.stub(:exit!).and_return(true)
+      allow(@ctl).to receive(:exit!).and_return(true)
       @ctl.help
       @ctl.fh_output.rewind
       output = @ctl.fh_output.gets(nil)
-      output.should =~ /#{Regexp.escape("extended")}\n  #{Regexp.escape("Extended omnibus-ctl")}/
+      expect(output).to match(/#{Regexp.escape("extended")}\n  #{Regexp.escape("Extended omnibus-ctl")}/)
     end
 
     it "should let a loaded command declare arity" do
-      @ctl.run(["arity", "some-arg"]).should == true
+      expect(@ctl.run(["arity", "some-arg"])).to eq(true)
     end
 
     it "should allow loaded commands with dashes in the name" do
-      @ctl.run(["name-with-dashes"]).should == true
+      expect(@ctl.run(["name-with-dashes"])).to eq(true)
     end
   end
 
   describe "run_sv_command" do
     before(:each) do
-      @ctl.stub(:get_all_services).and_return(["erchef", "chef-solr"])
-      @ctl.stub(:global_service_command_permitted).and_return(true)
-      @ctl.stub(:exit!).and_return(true)
+      allow(@ctl).to receive(:get_all_services).and_return(["erchef", "chef-solr"])
+      allow(@ctl).to receive(:global_service_command_permitted).and_return(true)
+      allow(@ctl).to receive(:exit!).and_return(true)
     end
 
     context "without a service" do
       it "should run the command against all services" do
         ["erchef", "chef-solr"].each do |service|
-          @ctl
-            .should_receive(:run_sv_command_for_service)
+          expect(@ctl)
+            .to receive(:run_sv_command_for_service)
             .with("stop", service)
             .and_return(0)
         end
@@ -285,23 +285,23 @@ describe Omnibus::Ctl do
 
       it "exits with the sum of all the status codes" do
         ["erchef", "chef-solr"].each do |service|
-          @ctl
-            .should_receive(:run_sv_command_for_service)
+          expect(@ctl)
+            .to receive(:run_sv_command_for_service)
             .with("status", service)
             .and_return(1)
         end
-        @ctl.should_receive(:exit!).with(2)
+        expect(@ctl).to receive(:exit!).with(2)
         @ctl.run_sv_command("status")
       end
 
       it "should check the command is permitted globally" do
         ["erchef", "chef-solr"].each do |service|
-          @ctl
-            .should_receive(:global_service_command_permitted)
+          expect(@ctl)
+            .to receive(:global_service_command_permitted)
             .with("status", service)
             .and_return(true)
-          @ctl
-            .should_receive(:run_sv_command_for_service)
+          expect(@ctl)
+            .to receive(:run_sv_command_for_service)
             .with("status", service)
             .and_return(0)
         end
@@ -310,11 +310,11 @@ describe Omnibus::Ctl do
 
       context "when the command is not permitted globally" do
         before(:each) do
-          @ctl.stub(:global_service_command_permitted).and_return(false)
+          allow(@ctl).to receive(:global_service_command_permitted).and_return(false)
         end
 
         it "should not execute the service command" do
-          @ctl.should_not_receive(:run_sv_command_for_service)
+          expect(@ctl).not_to receive(:run_sv_command_for_service)
           @ctl.run_sv_command("status")
         end
       end
@@ -322,29 +322,29 @@ describe Omnibus::Ctl do
 
     context "with a service" do
       it "should run the command against just one service" do
-        @ctl
-          .should_receive(:run_sv_command_for_service)
+        expect(@ctl)
+          .to receive(:run_sv_command_for_service)
           .with("stop", "erchef")
           .and_return(0)
-        @ctl
-          .should_not_receive(:run_sv_command_for_servcie)
+        expect(@ctl)
+          .not_to receive(:run_sv_command_for_servcie)
           .with("stop", "chef_solr")
         @ctl.run_sv_command("stop", "erchef")
       end
 
       it "exits with the status code of the service command" do
-        @ctl
-          .should_receive(:run_sv_command_for_service)
+        expect(@ctl)
+          .to receive(:run_sv_command_for_service)
           .with("status", "erchef")
           .and_return(3)
-        @ctl.should_receive(:exit!).with(3)
+        expect(@ctl).to receive(:exit!).with(3)
         @ctl.run_sv_command("status", "erchef")
       end
 
       it "should not check if the service is permitted globally" do
-        @ctl.should_not_receive(:global_service_command_permitted)
-        @ctl
-          .should_receive(:run_sv_command_for_service)
+        expect(@ctl).not_to receive(:global_service_command_permitted)
+        expect(@ctl)
+          .to receive(:run_sv_command_for_service)
           .with("status", "erchef")
           .and_return(0)
         @ctl.run_sv_command("status", "erchef")
@@ -355,64 +355,64 @@ describe Omnibus::Ctl do
   describe "run_sv_command_for_service" do
     before(:each) do
       @status = double(Process::Status)
-      @status.stub(:exitstatus).and_return(0)
+      allow(@status).to receive(:exitstatus).and_return(0)
     end
 
     context "when service is enabled" do
       before(:each) do
-        @ctl.stub(:service_enabled?).and_return(true)
+        allow(@ctl).to receive(:service_enabled?).and_return(true)
       end
 
       it "runs the service command from init" do
-        @ctl
-          .should_receive(:run_command)
+        expect(@ctl)
+          .to receive(:run_command)
           .with("/opt/chef-server/init/erchef start")
           .and_return(@status)
         @ctl.run_sv_command_for_service("start", "erchef")
       end
 
       it "returns the status code of the service command" do
-        @ctl.stub(:run_command).and_return(@status)
-        @ctl.run_sv_command_for_service("start", "erchef").should eq(0)
+        allow(@ctl).to receive(:run_command).and_return(@status)
+        expect(@ctl.run_sv_command_for_service("start", "erchef")).to eq(0)
       end
 
       context "when the command fails" do
         it "should return a non-zero status code" do
-          @status.stub(:exitstatus).and_return(3)
-          @ctl.stub(:run_command).and_return(@status)
-          @ctl.run_sv_command_for_service("start", "erchef").should eq(3)
+          allow(@status).to receive(:exitstatus).and_return(3)
+          allow(@ctl).to receive(:run_command).and_return(@status)
+          expect(@ctl.run_sv_command_for_service("start", "erchef")).to eq(3)
         end
       end
     end
 
     context "when the service is disabled" do
       before(:each) do
-        @ctl.stub(:service_enabled?).and_return(false)
+        allow(@ctl).to receive(:service_enabled?).and_return(false)
       end
 
       context "and the sv_cmd is 'status'" do
         it "should not run the 'status' command" do
-          @ctl.should_not_receive(:run_command)
+          expect(@ctl).not_to receive(:run_command)
           @ctl.run_sv_command_for_service("status", "erchef")
         end
 
         it "should return 0" do
-          @ctl.run_sv_command_for_service("status", "erchef").should eq(0)
+          expect(@ctl.run_sv_command_for_service("status", "erchef")).to eq(0)
         end
 
         it "should not log that the service is disabled" do
-          @ctl.should_not_receive(:log)
+          expect(@ctl).not_to receive(:log)
           @ctl.run_sv_command_for_service("status", "erchef")
         end
 
         context "and verbose logging is on" do
           before(:each) do
-            @ctl.stub(:verbose).and_return(true)
+            allow(@ctl).to receive(:verbose).and_return(true)
           end
 
           it "should log that the service is disabled" do
-            @ctl
-              .should_receive(:log)
+            expect(@ctl)
+              .to receive(:log)
               .with("erchef disabled")
             @ctl.run_sv_command_for_service("status", "erchef")
           end
@@ -422,26 +422,26 @@ describe Omnibus::Ctl do
       ["start", "stop", "restart"].each do |sv_cmd|
         context "and the sv_cmd is '#{sv_cmd}'" do
           it "should not run the '#{sv_cmd}' command" do
-            @ctl.should_not_receive(:run_command)
+            expect(@ctl).not_to receive(:run_command)
             @ctl.run_sv_command_for_service(sv_cmd, "erchef")
           end
 
           it "should return 0" do
-            @ctl.run_sv_command_for_service(sv_cmd, "erchef").should eq(0)
+            expect(@ctl.run_sv_command_for_service(sv_cmd, "erchef")).to eq(0)
           end
 
           it "should not log that the service is disabled" do
-            @ctl.should_not_receive(:log)
+            expect(@ctl).not_to receive(:log)
             @ctl.run_sv_command_for_service(sv_cmd, "erchef")
           end
 
           context "and verbose logging is on" do
             before(:each) do
-              @ctl.stub(:verbose).and_return(true)
+              allow(@ctl).to receive(:verbose).and_return(true)
             end
 
             it "should not log that the service is disabled" do
-              @ctl.should_not_receive(:log)
+              expect(@ctl).not_to receive(:log)
               @ctl.run_sv_command_for_service(sv_cmd, "erchef")
             end
           end
@@ -455,18 +455,18 @@ describe Omnibus::Ctl do
     let(:hidden_services)  { ["archer", "lana", "opscode-chef-mover"] }
 
     before(:each) do
-      @ctl.stub(:removed_services).and_return(removed_services)
-      @ctl.stub(:hidden_services).and_return(hidden_services)
+      allow(@ctl).to receive(:removed_services).and_return(removed_services)
+      allow(@ctl).to receive(:hidden_services).and_return(hidden_services)
     end
 
     context "for hidden services" do
       it "should allow all commands besides status" do
         valid_commands = service_commands - ["status"]
         hidden_services.product(["status"]).each do |svc, cmd|
-          @ctl.global_service_command_permitted(cmd, svc).should eq(false)
+          expect(@ctl.global_service_command_permitted(cmd, svc)).to eq(false)
         end
         hidden_services.product(valid_commands).each do |svc, cmd|
-          @ctl.global_service_command_permitted(cmd, svc).should eq(true)
+          expect(@ctl.global_service_command_permitted(cmd, svc)).to eq(true)
         end
       end
     end
@@ -475,10 +475,10 @@ describe Omnibus::Ctl do
       it "should only allow the stop command" do
         invalid_commands = service_commands - ["stop"]
         removed_services.product(invalid_commands).each do |svc, cmd|
-          @ctl.global_service_command_permitted(cmd, svc).should eq(false)
+          expect(@ctl.global_service_command_permitted(cmd, svc)).to eq(false)
         end
         removed_services.product(["stop"]).each do |svc, cmd|
-          @ctl.global_service_command_permitted(cmd, svc).should eq(true)
+          expect(@ctl.global_service_command_permitted(cmd, svc)).to eq(true)
         end
       end
     end
@@ -487,9 +487,9 @@ describe Omnibus::Ctl do
       it "should only allow the status command" do
         invalid_commands = service_commands - ["status"]
         invalid_commands.each do |cmd|
-          @ctl.global_service_command_permitted(cmd, "keepalived").should eq(false)
+          expect(@ctl.global_service_command_permitted(cmd, "keepalived")).to eq(false)
         end
-        @ctl.global_service_command_permitted("status", "keepalived").should eq(true)
+        expect(@ctl.global_service_command_permitted("status", "keepalived")).to eq(true)
       end
     end
 
@@ -497,7 +497,7 @@ describe Omnibus::Ctl do
       it "should allow all of the service commands" do
         services = ["chef", "postgresql", "bookshelf"]
         services.product(service_commands).each do |svc, cmd|
-          @ctl.global_service_command_permitted(cmd, svc).should eq(true)
+          expect(@ctl.global_service_command_permitted(cmd, svc)).to eq(true)
         end
       end
     end
@@ -505,35 +505,35 @@ describe Omnibus::Ctl do
 
   describe "removed_services" do
     it "should load the services from the running config" do
-      @ctl.should_receive(:running_config) do
+      expect(@ctl).to receive(:running_config) do
         {
           "chef_server" => {
             "removed_services" => ["couchdb", "mysql"]
           }
         }
       end
-      @ctl.removed_services().should eq(["couchdb", "mysql"])
+      expect(@ctl.removed_services()).to eq(["couchdb", "mysql"])
     end
 
     context "when removed services are not configured" do
       before(:each) do
-        @ctl.stub(:running_config)  do
+        allow(@ctl).to receive(:running_config)  do
           {"chef_server" => {}}
         end
       end
 
       it "should return an empty array" do
-        @ctl.removed_services.should eq([])
+        expect(@ctl.removed_services).to eq([])
       end
     end
 
     context "when #running_config returns nil" do
       before(:each) do
-        @ctl.stub(:running_config).and_return(nil)
+        allow(@ctl).to receive(:running_config).and_return(nil)
       end
 
       it "should return an empty array" do
-        @ctl.removed_services.should eq([])
+        expect(@ctl.removed_services).to eq([])
       end
     end
   end
@@ -547,18 +547,18 @@ EOF
 end
 
     it "checks if the file exists" do
-      File.should_receive(:exists?).with(file_path).and_return(false)
+      expect(File).to receive(:exists?).with(file_path).and_return(false)
       @ctl.running_config
     end
 
     context "when the file exists" do
       before(:each) do
-        File.stub(:exists?).and_return(true)
+        allow(File).to receive(:exists?).and_return(true)
       end
 
       it "should return the parsed contents of the file" do
-        File
-          .should_receive(:read)
+        expect(File)
+          .to receive(:read)
           .with(file_path)
           .and_return(file_contents)
         expected = { "chef_server" =>
@@ -566,17 +566,17 @@ end
             "removed_services" => ["sv1", "sv2"]
           }
         }
-        @ctl.running_config.should eq(expected)
+        expect(@ctl.running_config).to eq(expected)
       end
     end
 
     context "when the file doesn't exist" do
       before(:each) do
-        File.stub(:exists?).and_return(false)
+        allow(File).to receive(:exists?).and_return(false)
       end
 
       it "should return nil" do
-        @ctl.running_config.should eq(nil)
+        expect(@ctl.running_config).to eq(nil)
       end
     end
   end
@@ -588,7 +588,7 @@ end
       end
 
       it "returns 'private-chef'" do
-        @ctl.package_name.should eq("private-chef")
+        expect(@ctl.package_name).to eq("private-chef")
       end
     end
 
@@ -596,7 +596,7 @@ end
       it "should return the configured name" do
         %w{chef-server opscode-manage opscode-analytics}.each do |package|
           @ctl.name = package
-          @ctl.package_name.should eq(package)
+          expect(@ctl.package_name).to eq(package)
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,5 @@ require 'omnibus-ctl'
 RSpec.configure do |config|
   config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
-  config.treat_symbols_as_metadata_keys_with_true_values = true
 end
 


### PR DESCRIPTION
Most of this was done automatically with [Transpec](http://yujinakayama.me/transpec/). See the commit message on d8372c9 for details.

I bundled and it pulled in 3.2 and got warnings. This pins RSpec to 3.2 in the development dependencies and does updates to remove all of the warnings.