### PR TITLE
command callback hooks, and make 'cleanse' aware of external services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 branches:
   only:
     - master

--- a/lib/omnibus-ctl/version.rb
+++ b/lib/omnibus-ctl/version.rb
@@ -1,5 +1,5 @@
 module Omnibus
   class Ctl
-    VERSION = "0.3.6"
+    VERSION = "0.4.0"
   end
 end

--- a/omnibus-ctl.gemspec
+++ b/omnibus-ctl.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |s|
   s.name        = "omnibus-ctl"
   s.version     = Omnibus::Ctl::VERSION
   s.authors     = ["Opscode, Inc."]
-  s.email       = ["legal@opscode.com"]
-  s.homepage    = "http://github.com/opscode/omnibus-ctl"
+  s.email       = ["legal@chef.io"]
+  s.homepage    = "http://github.com/chef/omnibus-ctl"
   s.summary     = %q{Provides command line control for omnibus packages}
   s.description = %q{Provides command line control for omnibus pakcages, rarely used as a gem}
 

--- a/spec/data/extend.rb
+++ b/spec/data/extend.rb
@@ -2,3 +2,7 @@ add_command("extended", "Extended omnibus-ctl") do |*args|
   log "I have extended omnibus-ctl with a new command"
   true
 end
+
+add_command("exit-non-zero", "Something") { |*args| exit! 10 }
+add_command("exit-zero", "Something") { |*args| exit! 0 }
+add_command('clean-exit', 'Something') { |*args| 0 }


### PR DESCRIPTION
This PR adds overridable subclass callbacks for execution pre/post command run, allowing subclasses to customize command behaviors.  In particular, this is being used first by chef-server-ctl to 

-  added hooks for command pre/post run.  pre-command hooks can cause a
  command to be aborted by returning false. 
- cleanse: new flag --with-external, used by hooks for components that
  may house their data externally and will need to clean then via means other than nuking /var/lib. 
- cleanse: output doc format changes and additional words to explain
  the effects of using/not using --with-external
- moved `backup_dir` to instance var. This allows subclasses hooking that command access to the backup location for `cleanse`. 

/cc @chef/lob 

See also: https://github.com/chef/chef-server/pull/486
