### PR TITLE
Handle run_command out of a subcommand better.

### DIFF
--- a/lib/omnibus-ctl/version.rb
+++ b/lib/omnibus-ctl/version.rb
@@ -1,5 +1,5 @@
 module Omnibus
   class Ctl
-    VERSION = "0.4.0"
+    VERSION = "0.4.1"
   end
 end


### PR DESCRIPTION
* Correctly handle ctl commands that exit by returning the result of
  run_command
* Replace recently added usage of is_integer? with something that's not broken.
  Left is_integer? alone so that we don't risk breaking existing
  behaviors that depend on its incorrectness.
* in running_service_config, don't munge the key - that is only
  applicable at the top level

ping @lob