### PR TITLE
include source file and line for errors in commands

### DIFF
--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -170,7 +170,7 @@ module Omnibus
     end
 
     def load_file(filepath)
-      eval(IO.read(filepath))
+      eval(IO.read(filepath), nil, filepath, 1)
     end
 
     def add_command(name, description, arity=1, &block)

--- a/lib/omnibus-ctl/version.rb
+++ b/lib/omnibus-ctl/version.rb
@@ -1,5 +1,5 @@
 module Omnibus
   class Ctl
-    VERSION = "0.4.2"
+    VERSION = "0.4.3"
   end
 end


### PR DESCRIPTION
When a custom command fails, this change ensures file and line number are correctly reported. 