### PR TITLE
License acceptance during ctl reconfigure

### DIFF
--- a/spec/omnibus-ctl_spec.rb
+++ b/spec/omnibus-ctl_spec.rb
@@ -241,7 +241,7 @@ describe Omnibus::Ctl do
 
     it "exits 2 if the command is found, but not with the arity you provided on the cli" do
       begin
-        @ctl.run(["reconfigure", "not-found"])
+        @ctl.run(["uninstall", "not-found"])
       rescue SystemExit => e
        exit_code = e.status
       end


### PR DESCRIPTION
This PR adds license checking functionality to `ctl reconfigure` command. At a high level this PR:

1. Makes `ctl reconfigure` display the LICENSE to the user and asks for acceptance if a license exists for a project. 
2. Enables `--accept-license` CLI option to be used in scripts.

More details about this feature can be found [here](https://docs.google.com/a/opscode.com/document/d/1GqI4Ofr4udY5QM3HgJPVFX_BZUnzk8et06ZsVZeCYM4/edit?usp=sharing)

I have been investigating which component is the best to implement this functionality. I have thought about using:

1. `enterprise-chef-common` cookbook which is shared across most of our projects.
2. Adding a new cookbook called `chef-license` which contains this logic.

The main issue I ran into was to implement `--accept-license` functionality. `reconfigure()` runs Chef and the only way to parameterize the chef run is to use `--json-attributes` option which is already being used with file `"#{base_path}/embedded/cookbooks/dna.json"` in reconfigure.

I'm open to suggestions of implementing this in a different place. And yes this change will be a breaking change and we are working on a communication plan [here](https://docs.google.com/a/opscode.com/document/d/1GqI4Ofr4udY5QM3HgJPVFX_BZUnzk8et06ZsVZeCYM4/edit?usp=sharing).

Please LMK of your thoughts and please include others who would be interested in what's happening here :smile: If all is good I will finalize the PR with more tests. 

/cc: @nellshamrell, @stevendanna, @marcparadise, @smith, @tylercloke, @sdelano, @schisamo, @patrick-wright