### PR TITLE
Add global pre-hook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Then run the tests:
 bin/rspec
 ```
 
-## Framework API
+## Command API
 
 There are two main functions you will use in your `*-ctl` project to add commands.
 
@@ -66,6 +66,27 @@ Another Category:
 ```
 
 If you only use `add_command_under_category` to add your custom commands, everything will be outputted under a category.
+
+## Pre-hook API
+
+### add_global_pre_hook(string, ruby_block)
+
+This method will add a global pre-hook block that will be executed before any
+*-ctl command is run. If the pre-hook raises an exception it will cause an early
+exit before the command is run.
+
+Input Arguments:
+
+1. Name of the hook
+1. Ruby block of the code to be executed.
+
+### Sample
+
+```ruby
+add_global_pre_hook "ensure that the user is always root" do
+  raise "You must run this command as root" unless Process.uid == 0
+end
+```
 
 ## Releasing
 

--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -151,6 +151,7 @@ module Omnibus
     def self.to_method_name(name)
       name.gsub(/-/, '_').to_sym
     end
+
     def to_method_name(name)
       Ctl.to_method_name(name)
     end
@@ -185,21 +186,16 @@ module Omnibus
       eval(IO.read(filepath), nil, filepath, 1)
     end
 
-    def add_command(name, description, arity=1, &block)
-      @command_map[name] = { :desc => description, :arity => arity }
-      metaclass = class << self; self; end
-      # Ruby does not like dashes in method names
-      method_name = to_method_name(name).to_sym
-      metaclass.send(:define_method, method_name) { |*args| block.call(*args) }
+    def add_command(name, description, arity = 1, &block)
+      @command_map[name] = { desc: description, arity: arity }
+      self.class.send(:define_method, to_method_name(name).to_sym, block)
     end
 
-    def add_command_under_category(name, category, description, arity=1, &block)
+    def add_command_under_category(name, category, description, arity = 1, &block)
       # add new category if it doesn't exist
-      @category_command_map[category] = {} unless @category_command_map.has_key?(category)
-      @category_command_map[category][name] = { :desc => description, :arity => arity }
-      metaclass = class << self; self; end
-      method_name = to_method_name(name).to_sym
-      metaclass.send(:define_method, method_name) { |*args| block.call(*args) }
+      @category_command_map[category] ||= {}
+      @category_command_map[category][name] = { desc: description, arity: arity }
+      self.class.send(:define_method, to_method_name(name).to_sym, block)
     end
 
     def exit!(code)

--- a/spec/data/global_pre_hook.rb
+++ b/spec/data/global_pre_hook.rb
@@ -1,0 +1,4 @@
+add_global_pre_hook("always-run-me-pre-hook") do
+  log "I have extended omnibus-ctl with a global pre hook that runs before all commands"
+  true
+end


### PR DESCRIPTION
#39 The existing omnibus-ctl currently has a per-command pre-hook system that is used to defer external service commands but there is no easy way to implement a global pre hook that is run before each omnibus ctl command. This commit adds an easy to use global pre hook system that registers a block that will get eval'd before each omnibus command.

```
add_global_pre_hook "ensure that the user is always root" do
  raise "You must run this command as root" unless Process.uid == 0
end
```

[More context](https://gist.github.com/ryancragun/b2133f2bf61a9054b7f6074bea9eedc2)