### PR TITLE
Directly use the embedded sv instead of the init symlinks.

### DIFF
--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -360,7 +360,7 @@ EOM
     # run an sv command for a specific service name
     def run_sv_command_for_service(sv_cmd, service_name)
       if service_enabled?(service_name)
-        status = run_command("#{base_path}/init/#{service_name} #{sv_cmd}")
+        status = run_command("#{base_path}/embedded/bin/sv #{sv_cmd} #{service_name}")
         status.exitstatus
       else
         log "#{service_name} disabled" if sv_cmd == "status" && verbose

--- a/spec/omnibus-ctl_spec.rb
+++ b/spec/omnibus-ctl_spec.rb
@@ -404,10 +404,10 @@ describe Omnibus::Ctl do
         allow(@ctl).to receive(:service_enabled?).and_return(true)
       end
 
-      it "runs the service command from init" do
+      it "runs the service command using the embedded sv" do
         expect(@ctl)
           .to receive(:run_command)
-          .with("/opt/chef-server/init/erchef start")
+          .with("/opt/chef-server/embedded/bin/sv start erchef")
           .and_return(@status)
         @ctl.run_sv_command_for_service("start", "erchef")
       end


### PR DESCRIPTION
The symlinks in init/ are created by the runit cookbook, and on Debian
it creates a wrapper script instead of simple symlinks. This wrapper
script encodes `/usr/bin/sv` as the control binary.

Instead of relying on the symlinks being as expected, directly use the
binary that is embedded anyway.

Fixes #53. Fixes running chef-server on Debian.