### PR TITLE
Explicitly set SVDIR to the service_dir

### DIFF
--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -58,8 +58,10 @@ module Omnibus
       @force_exit = false
       @global_pre_hooks = {}
 
-      # Remove SVDIR if it is set
-      ENV.delete('SVDIR')
+      # TODO(ssd) 2017-03-28: Set SVDIR explicitly. Once we fix a bug
+      # in our debian support, where we rely on system-installed
+      # runit, we can likely change this back to ENV.delete("SVDIR")
+      ENV['SVDIR'] = service_path
 
       # backwards compat command map that does not have categories
       @command_map = { }


### PR DESCRIPTION
We currently have a bug on Debian where we rely on the
system-installed runit. The system installed runit does not have our
patch to reset the servicedir. Users were previously working around
this by setting SVDIR explicitly. This preserves those users ability
to use Chef server on the next release. The full fix will be to ensure
we don't rely on the system-installed runit on Debian.

Signed-off-by: Steven Danna <steve@chef.io>