### PR TITLE
Exclude more files from "ctl tail" output (closes #46)

### DIFF
--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -48,7 +48,7 @@ module Omnibus
       @log_path = "/var/log/#{name}"
       @data_path = "/var/opt/#{name}"
       @etc_path = "/etc/#{name}"
-      @log_exclude = '(config|lock|@|gzip|tgz|gz)'
+      @log_exclude = '(config|lock|@|bz2|gz|gzip|tbz2|tgz|txz|xz|zip)'
       @log_path_exclude = ['*/sasl/*']
       @fh_output = STDOUT
       @kill_users = []


### PR DESCRIPTION
This patch adds additional extensions to the list of filename extensions excluded from `ctl tail` output. 

Newly added filename extensions are:

- bz2
- tar
- tbz2
- tgz
- txz
- xz
- zip

Obvious fix.