### PR TITLE
Quote glob patterns in find command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   bundler: true
 language: ruby
 rvm:
-  - 1.9.3
+  - 2.2.6
 script:
   - bundle install --binstubs
   - ./bin/rspec spec/

--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -579,7 +579,7 @@ EOM
       command = "find -L #{log_path}"
       command << "/#{args[1]}" if args[1]
       command << ' -type f'
-      command << log_path_exclude.map { |path| " -not -path #{path}" }.join(' ')
+      command << log_path_exclude.map { |path| " -not -path '#{path}'" }.join(' ')
       command << " | grep -E -v '#{log_exclude}' | xargs tail --follow=name --retry"
 
       system(command)


### PR DESCRIPTION
An unquoted glob will be interpreted by the shell before the command
is executed.  If the user is in a directory where the globs match
such as in `/var/log/opscode` the shell will expand the glob creating
an invalid find command:

    root@api:~# cd /var/log/opscode
    root@api:/var/log/opscode# chef-server-ctl tail
    find: paths must precede expression: bookshelf/sasl/2
    Usage: find [-H] [-L] [-P] [-Olevel] [-D help|tree|search|stat|rates|opt|exec] [path...] [expression]
    tail: cannot follow '-' by name

Quoting the glob fixes this.  This is a quick-fix for
chef/chef-server#1333. However, someone might want to re-implement
this in ruby as a more robust fix.

Signed-off-by: Steven Danna <steve@chef.io>