### PR TITLE
Use dist constant in package_name method

### DIFF
--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -429,7 +429,8 @@ EOM
     # 'opscode', not 'private-chef'
     def package_name
       case @name
-      when "opscode"
+      # The "opscode" in /opt/opscode
+      when ::ChefUtils::Dist::Org::LEGACY_CONF_DIR
         "private-chef"
       else
         @name


### PR DESCRIPTION
This is needed to get word marks properly working on Cinc.

Signed-off-by: Lance Albertson <lance@osuosl.org>
