### PR TITLE
Use client CLI dist constant when executing chef runs

### DIFF
--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -498,7 +498,7 @@ EOM
         log_level = ""
       end
       remove_old_node_state
-      cmd = "#{base_path}/embedded/bin/chef-client #{log_level} -z -c #{base_path}/embedded/cookbooks/solo.rb -j #{attr_location}"
+      cmd = "#{base_path}/embedded/bin/#{ChefUtils::Dist::Infra::CLIENT} #{log_level} -z -c #{base_path}/embedded/cookbooks/solo.rb -j #{attr_location}"
       cmd += " #{args}" unless args.empty?
       run_command(cmd)
     end


### PR DESCRIPTION
This will avoid us from using the wrapper in Cinc and directly use our binary.

Signed-off-by: Lance Albertson <lance@osuosl.org>
